### PR TITLE
Make links compatible with GH pages renderer

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 # beancount: Double-Entry Accounting from Text Files (Organization)
 
 See home page of `beancount` repository for project details:
-https://github.com/beancount/beancount/blob/master/README.rst
+<https://github.com/beancount/beancount/blob/master/README.rst>
 
 The latest documentation is available in Google Docs at:
-http://furius.ca/beancount/doc/index
+<http://furius.ca/beancount/doc/index>
 
 A frequently updated copy  of the documentation is also convert to Markdown and
-available at: https://beancount.github.io/docs/.
+available at: <https://beancount.github.io/docs/>.

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 # beancount: Double-Entry Accounting from Text Files (Organization)
 
 See home page of `beancount` repository for project details:
-<https://github.com/beancount/beancount/blob/master/README.rst>
+<https://github.com/beancount/beancount/>
 
 The latest documentation is available in Google Docs at:
 <http://furius.ca/beancount/doc/index>


### PR DESCRIPTION
On https://beancount.github.io, the URLs are not clickable as a consequence of GitHub's stricter rendering of Markdown on GitHub Pages. (The Pages renderer requires explicit link syntax, whereas the GH app will just linkify anything that looks like a URL.)

I also changed the first link for accuracy (it now is in fact the homepage of the beancount repository as described, and this is where the same README.rst is rendered).

I have been seeing this page frequently as of late, as I am digging into learning beancount and my browser autocomplete tends to bring me here; this will make it more useful as all of these links tend to be what I am actually looking for, and it's a drag when they are not clickable. I suspect I'm not the only one who feels this way.